### PR TITLE
🎨📝 Refactor Device

### DIFF
--- a/device/device.go
+++ b/device/device.go
@@ -50,14 +50,14 @@ func (f *Feature) Set(value string) {
 	f.devRef.transport.Publish(f.SetTopic, []byte(value), 1, false)
 }
 
-func (f *Feature) Watch(callback func(msg messaging.Message)) {
-	f.devRef.transport.Subscribe(f.GetTopic, 1, callback)
+func (f *Feature) OnSet(callback func(msg messaging.Message)) {
+	f.devRef.transport.Subscribe(f.SetTopic, 1, callback)
 }
 
 func (f *Feature) Update(value string) {
 	f.devRef.transport.Publish(f.GetTopic, []byte(value), 1, true)
 }
 
-func (f *Feature) OnSet(callback func(msg messaging.Message)) {
-	f.devRef.transport.Subscribe(f.SetTopic, 1, callback)
+func (f *Feature) OnUpdate(callback func(msg messaging.Message)) {
+	f.devRef.transport.Subscribe(f.GetTopic, 1, callback)
 }

--- a/device/device_test.go
+++ b/device/device_test.go
@@ -10,4 +10,9 @@ func TestNewDevice(t *testing.T) {
 	if d.Topic != "test" {
 		t.Errorf("Expected topic of %s, got %s", "test", d.Topic)
 	}
+
+	if d.HasFeature("") {
+		t.Error("Expected false, got ", d.HasFeature(""))
+	}
+
 }

--- a/device/manager.go
+++ b/device/manager.go
@@ -49,6 +49,7 @@ func (m *Manager) Add(topic string) {
 			if ft.GetTopic == "" {
 				ft.GetTopic = fmt.Sprintf("%s/%s/get", topic, name)
 			}
+			ft.devRef = dev
 		}
 
 		go m.forHandler(func(handler DeviceHandler) {

--- a/homekit/device_holder.go
+++ b/homekit/device_holder.go
@@ -97,7 +97,7 @@ func createAccessoryFromDevice(d *device.Device) *accessory.Accessory {
 				feature.Set(out)
 			}
 		})
-		feature.Watch(func(msg messaging.Message) {
+		feature.OnUpdate(func(msg messaging.Message) {
 			ch.UpdateValue(string(msg.Payload()))
 		})
 

--- a/homekit/device_holder.go
+++ b/homekit/device_holder.go
@@ -78,7 +78,6 @@ func createAccessoryFromDevice(d *device.Device) *accessory.Accessory {
 		}
 		svc.AddCharacteristic(ch)
 		chCount++
-		featureName := name
 
 		ch.OnValueUpdateFromConn(func(conn net.Conn, c *characteristic.Characteristic, newValue, oldValue interface{}) {
 			var out string
@@ -95,10 +94,10 @@ func createAccessoryFromDevice(d *device.Device) *accessory.Accessory {
 			}
 
 			if out != "" {
-				d.Set(featureName, out)
+				feature.Set(out)
 			}
 		})
-		d.Watch(name, func(msg messaging.Message) {
+		feature.Watch(func(msg messaging.Message) {
 			ch.UpdateValue(string(msg.Payload()))
 		})
 


### PR DESCRIPTION
Remove a number of methods from `Device` that dealt with getting/setting
the topic and publishing or subscribing to a feature. Instead attach
those methods to `Feature` so they can be called directly on them. This
feels much more natural and simplifies the API a bit as we can get rid
of some error checking (since you can't call those methods on features
that don't exist which we had to guard on before).

However, since the `Set`, `OnSet`, `Update` and `Watch` methods on features do require access
to the device transport I now have to maintain a reference to the partent
struct/device. An alternative approach could be to embed a reference to
the transport in the features too.

This also gets rid of the `GetTopic` and `SetTopic` methods entirely as
they're no longer necessary. Since the manager always sets the
`GetTopic` and `SetTopic` attributes on a feature they can be used
directly instead of going through the Device.