### PR TITLE
☔️ Add test for `device.PublishMeta()`

### DIFF
--- a/device/device_test.go
+++ b/device/device_test.go
@@ -1,7 +1,9 @@
 package device
 
 import (
+	"bytes"
 	"github.com/hemtjanst/hemtjanst/messaging"
+	"reflect"
 	"testing"
 )
 
@@ -14,5 +16,30 @@ func TestNewDevice(t *testing.T) {
 	if d.HasFeature("") {
 		t.Error("Expected false, got ", d.HasFeature(""))
 	}
+}
 
+func TestPublishMeta(t *testing.T) {
+	m := &messaging.TestingMessenger{}
+	d := NewDevice("lightbulb/kitchen", m)
+	err := d.PublishMeta()
+	if err != nil {
+		t.Error("Expected to successfully publish meta, got ", err)
+	}
+
+	if m.Action != "publish" {
+		t.Error("Expected to publish, but tried to ", m.Action)
+	}
+	if !reflect.DeepEqual(m.Topic, []string{"lightbulb/kitchen/meta"}) {
+		t.Error("Expected topic to be lightbulb/kitchen/meta, got ", m.Topic)
+	}
+	if m.Qos != 1 {
+		t.Error("Expected QoS of 1, got ", m.Qos)
+	}
+	if !m.Persist {
+		t.Error("Expected persist, got ", m.Persist)
+	}
+	msg := `{"Topic":"lightbulb/kitchen","name":"","manufacturer":"","model":"","serialNumber":"","type":"","feature":null}`
+	if !bytes.Equal(m.Message, []byte(msg)) {
+		t.Errorf("Expected %s, got %s", msg, string(m.Message))
+	}
 }

--- a/messaging/mqtt.go
+++ b/messaging/mqtt.go
@@ -125,8 +125,29 @@ func (m *mqttMessenger) Unsubscribe(topics ...string) {
 }
 
 // TestingMessenger is a no-op messenger useful for when running tests
-type TestingMessenger struct{}
+type TestingMessenger struct {
+	Action   string
+	Topic    []string
+	Message  []byte
+	Qos      int
+	Persist  bool
+	Callback func(Message)
+}
 
-func (*TestingMessenger) Publish(destination string, message []byte, qos int, persist bool) {}
-func (*TestingMessenger) Subscribe(dsource string, qos int, callback func(Message))         {}
-func (*TestingMessenger) Unsubscribe(sources ...string)                                     {}
+func (tm *TestingMessenger) Publish(topic string, message []byte, qos int, persist bool) {
+	tm.Action = "publish"
+	tm.Topic = []string{topic}
+	tm.Message = message
+	tm.Qos = qos
+	tm.Persist = persist
+}
+func (tm *TestingMessenger) Subscribe(topic string, qos int, callback func(Message)) {
+	tm.Action = "subscribe"
+	tm.Topic = []string{topic}
+	tm.Qos = qos
+	tm.Callback = callback
+}
+func (tm *TestingMessenger) Unsubscribe(topics ...string) {
+	tm.Action = "unsubscribe"
+	tm.Topic = topics
+}


### PR DESCRIPTION
Expand `message.TestingMessenger` to store the action, message, topic, qos, persistance and callback on the struct so we can inspect their values in tests.