### PR TITLE
Don't make assumptions if type is missing

### DIFF
--- a/homekit/device_holder.go
+++ b/homekit/device_holder.go
@@ -82,7 +82,7 @@ func (h *deviceHolder) deviceUpdate(d *device.Device) {
 
 func (h *deviceHolder) createAccessory() (err error) {
 	if h.accessory != nil {
-		return fmt.Errorf("Accessory already created for device %s", h.device.Topic)
+		return fmt.Errorf("accessory already created for device %s", h.device.Topic)
 	}
 
 	info := accessory.Info{
@@ -101,6 +101,10 @@ func (h *deviceHolder) createAccessory() (err error) {
 }
 func (h *deviceHolder) updateAccessory() (err error) {
 	sType := util.ServiceType(h.device.Type)
+
+	if sType == "" {
+		return fmt.Errorf("unknown type %s", h.device.Type)
+	}
 
 	// TODO: Compare with current service/characteristics if any are set
 	//       instead of creating new ones.

--- a/homekit/util/service.go
+++ b/homekit/util/service.go
@@ -92,6 +92,6 @@ func ServiceType(t string) string {
 	case "windowcovering":
 		return service.TypeWindowCovering
 	default:
-		return service.TypeSwitch
+		return ""
 	}
 }


### PR DESCRIPTION
Don't assume that devices that have missing or unknown `type`-field in the metadata to be a switch - return error instead