### PR TITLE
Update all our (direct) dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -81,14 +81,14 @@
   name = "golang.org/x/crypto"
   packages = [
     "chacha20poly1305",
-    "chacha20poly1305/internal/chacha20",
     "curve25519",
     "ed25519",
     "ed25519/internal/edwards25519",
     "hkdf",
+    "internal/chacha20",
     "poly1305"
   ]
-  revision = "b176d7def5d71bdd214203491f89843ed217f420"
+  revision = "13931e22f9e72ea58bb73048bc752b48c6d4d4ac"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -67,8 +67,8 @@
 [[projects]]
   name = "github.com/satori/go.uuid"
   packages = ["."]
-  revision = "879c5887cd475cd7864858769793b2ceb0d44feb"
-  version = "v1.1.0"
+  revision = "f58768cc1a7a7e77a3bd49e98cdd21419399b6a3"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
@@ -107,6 +107,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "70b579d5b5895006c2c1a26aa2e8d4c6d40ba63440ddeda2605979ec8fa939eb"
+  inputs-digest = "14d351e0dadaad586398f9614d6784009d201a9d0f246a0b29497f38118c4b0e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,25 +4,52 @@
 [[projects]]
   branch = "master"
   name = "github.com/agl/ed25519"
-  packages = [".","edwards25519"]
+  packages = [
+    ".",
+    "edwards25519"
+  ]
   revision = "5312a61534124124185d41f09206b9fef1d88403"
 
 [[projects]]
   branch = "master"
-  name = "github.com/brutella/hc"
-  packages = ["accessory","characteristic","crypto","crypto/chacha20poly1305","crypto/curve25519","crypto/hkdf","db","event","hap","hap/controller","hap/data","hap/endpoint","hap/http","hap/pair","log","service","util"]
-  revision = "5f75b70715efe858574e7d6719878ce060693db1"
+  name = "github.com/brutella/dnssd"
+  packages = [
+    ".",
+    "log"
+  ]
+  revision = "75c3c0c65b2b195ff1805209b88907db71aad88f"
 
 [[projects]]
-  name = "github.com/cenkalti/backoff"
-  packages = ["."]
-  revision = "32cd0c5b3aef12c76ed64aaf678f6c79736be7dc"
-  version = "v1.0.0"
+  branch = "master"
+  name = "github.com/brutella/hc"
+  packages = [
+    "accessory",
+    "characteristic",
+    "crypto",
+    "crypto/chacha20poly1305",
+    "crypto/curve25519",
+    "crypto/hkdf",
+    "db",
+    "event",
+    "hap",
+    "hap/controller",
+    "hap/data",
+    "hap/endpoint",
+    "hap/http",
+    "hap/pair",
+    "log",
+    "service",
+    "util"
+  ]
+  revision = "b50d8bf0877cdac0b9d115c40828be5bc21d33b0"
 
 [[projects]]
   branch = "master"
   name = "github.com/eclipse/paho.mqtt.golang"
-  packages = [".","packets"]
+  packages = [
+    ".",
+    "packets"
+  ]
   revision = "720ed1a92c623623f00233e4bcd8d513d6e2fbe7"
 
 [[projects]]
@@ -32,16 +59,10 @@
   revision = "c20e083e31230b84ffa23c5d2fb0bc55f5292681"
 
 [[projects]]
-  branch = "master"
-  name = "github.com/grandcat/zeroconf"
-  packages = ["."]
-  revision = "2f133dcabb8c1dc0e63ec6bb9e2c405179db3033"
-
-[[projects]]
-  branch = "master"
   name = "github.com/miekg/dns"
   packages = ["."]
-  revision = "bbca4873b326f5dc54bfe31148446d4ed79a5a02"
+  revision = "5ec25f2a5044291b6c8abf43ed8a201da241e69e"
+  version = "v1.0.3"
 
 [[projects]]
   name = "github.com/satori/go.uuid"
@@ -58,24 +79,34 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["chacha20poly1305","chacha20poly1305/internal/chacha20","curve25519","hkdf","poly1305"]
+  packages = [
+    "chacha20poly1305",
+    "chacha20poly1305/internal/chacha20",
+    "curve25519",
+    "ed25519",
+    "ed25519/internal/edwards25519",
+    "hkdf",
+    "poly1305"
+  ]
   revision = "b176d7def5d71bdd214203491f89843ed217f420"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
-  packages = ["bpf","idna","internal/iana","internal/socket","ipv4","ipv6","proxy","websocket"]
+  packages = [
+    "bpf",
+    "internal/iana",
+    "internal/socket",
+    "ipv4",
+    "ipv6",
+    "proxy",
+    "websocket"
+  ]
   revision = "1c05540f6879653db88113bc4a2b70aec4bd491f"
-
-[[projects]]
-  branch = "master"
-  name = "golang.org/x/text"
-  packages = ["internal/gen","internal/triegen","internal/ucd","secure/bidirule","transform","unicode/bidi","unicode/cldr","unicode/norm","unicode/rangetable"]
-  revision = "b19bf474d317b857955b12035d2c5acb57ce8b01"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "410dc7964370d941f77079feadd3033d870cc4d7b6fe7beefcc645172e1b3012"
+  inputs-digest = "70b579d5b5895006c2c1a26aa2e8d4c6d40ba63440ddeda2605979ec8fa939eb"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -50,7 +50,7 @@
     ".",
     "packets"
   ]
-  revision = "720ed1a92c623623f00233e4bcd8d513d6e2fbe7"
+  revision = "750c97f293745e8220737ef933da2ec829d2fddd"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -102,7 +102,7 @@
     "proxy",
     "websocket"
   ]
-  revision = "1c05540f6879653db88113bc4a2b70aec4bd491f"
+  revision = "5ccada7d0a7ba9aeb5d3aca8d3501b4c2a509fec"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -11,10 +11,6 @@
   name = "github.com/gosexy/to"
 
 [[constraint]]
-  branch = "master"
-  name = "github.com/oleksandr/bonjour"
-
-[[constraint]]
   name = "github.com/satori/go.uuid"
   version = "1.1.0"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -12,7 +12,7 @@
 
 [[constraint]]
   name = "github.com/satori/go.uuid"
-  version = "1.1.0"
+  version = "1.2.0"
 
 [[constraint]]
   name = "github.com/spf13/pflag"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -13,11 +13,3 @@
 [[constraint]]
   name = "github.com/satori/go.uuid"
   version = "1.2.0"
-
-[[constraint]]
-  name = "github.com/spf13/pflag"
-  version = "1.0.0"
-
-[[constraint]]
-  branch = "master"
-  name = "golang.org/x/net"

--- a/homekit/bridge/config.go
+++ b/homekit/bridge/config.go
@@ -62,16 +62,16 @@ func defaultConfig(name string) *Config {
 }
 
 // txtRecords returns the config formatted as mDNS txt records
-func (cfg Config) txtRecords() []string {
-	return []string{
-		fmt.Sprintf("pv=%s", cfg.protocol),
-		fmt.Sprintf("id=%s", cfg.id),
-		fmt.Sprintf("c#=%d", cfg.version),
-		fmt.Sprintf("s#=%d", cfg.state),
-		fmt.Sprintf("sf=%d", to.Int64(cfg.discoverable)),
-		fmt.Sprintf("ff=%d", to.Int64(cfg.mfiCompliant)),
-		fmt.Sprintf("md=%s", cfg.name),
-		fmt.Sprintf("ci=%d", cfg.categoryId),
+func (cfg Config) txtRecords() map[string]string {
+	return map[string]string{
+		"pv": cfg.protocol,
+		"id": cfg.id,
+		"c#": fmt.Sprintf("%d", cfg.version),
+		"s#": fmt.Sprintf("%d", cfg.state),
+		"sf": fmt.Sprintf("%d", to.Int64(cfg.discoverable)),
+		"ff": fmt.Sprintf("%d", to.Int64(cfg.mfiCompliant)),
+		"md": cfg.name,
+		"ci": fmt.Sprintf("c%d", cfg.categoryId),
 	}
 }
 

--- a/homekit/bridge/ip_transport.go
+++ b/homekit/bridge/ip_transport.go
@@ -2,11 +2,13 @@ package bridge
 
 import (
 	"bytes"
+	"context"
 	"io/ioutil"
 	"net"
 	"sync"
-	"time"
+	_ "time"
 
+	"github.com/brutella/dnssd"
 	"github.com/brutella/hc/accessory"
 	"github.com/brutella/hc/characteristic"
 	"github.com/brutella/hc/db"
@@ -19,12 +21,11 @@ import (
 )
 
 type ipTransport struct {
-	config    *Config
-	context   hap.Context
-	server    http.Server
-	keepAlive *hap.KeepAlive
-	mutex     *sync.Mutex
-	mdns      *MDNSService
+	config  *Config
+	context hap.Context
+	server  http.Server
+	mutex   *sync.Mutex
+	mdns    *MDNSService
 
 	storage  util.Storage
 	database db.Database
@@ -34,6 +35,14 @@ type ipTransport struct {
 
 	// Used to communicate between different parts of the program (e.g. successful pairing with HomeKit)
 	emitter event.Emitter
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	responder dnssd.Responder
+	handle    dnssd.ServiceHandle
+
+	stopped chan struct{}
 }
 
 // NewIPTransport creates a transport to provide accessories over IP.
@@ -77,6 +86,16 @@ func NewIPTransport(config Config, a *accessory.Accessory, as ...*accessory.Acce
 	cfg.load(storage)
 
 	device, err := hap.NewSecuredDevice(cfg.id, hap_pin, database)
+	if err != nil {
+		return nil, err
+	}
+
+	responder, err := dnssd.NewResponder()
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
 
 	t := &ipTransport{
 		storage:   storage,
@@ -87,6 +106,10 @@ func NewIPTransport(config Config, a *accessory.Accessory, as ...*accessory.Acce
 		mutex:     &sync.Mutex{},
 		context:   hap.NewContextForSecuredDevice(device),
 		emitter:   event.NewEmitter(),
+		responder: responder,
+		ctx:       ctx,
+		cancel:    cancel,
+		stopped:   make(chan struct{}),
 	}
 
 	t.addAccessory(a)
@@ -128,36 +151,52 @@ func (t *ipTransport) Start() {
 	// Publish server port which might be different then `t.config.Port`
 	t.config.servePort = int(to.Int64(s.Port()))
 
-	mdns := NewMDNSService(t.config)
-	t.mdns = mdns
+	service := newService(t.config)
+	t.handle, _ = t.responder.Add(service)
 
-	mdns.Publish()
+	mdnsCtx, mdnsCancel := context.WithCancel(t.ctx)
+	defer mdnsCancel()
+
+	mdnsStop := make(chan struct{})
+	go func() {
+		t.responder.Respond(mdnsCtx)
+		log.Debug.Println("mdns responder stopped")
+		mdnsStop <- struct{}{}
+	}()
+
+	// keepAliveCtx, keepAliveCancel := context.WithCancel(t.ctx)
+	// defer keepAliveCancel()
+	//
+	// // Send keep alive notifications to all connected clients every 10 minutes
+	// keepAlive := hap.NewKeepAlive(10*time.Minute, t.context)
+	// go func() {
+	// 	keepAlive.Start(keepAliveCtx)
+	// 	log.Info.Println("Keep alive stopped")
+	// }()
 
 	// Publish accessory ip
-	log.Info.Println("Accessory IP is", t.config.IP)
+	log.Info.Printf("Accessory address is %s:%s\n", t.config.IP, s.Port())
 
-	// Send keep alive notifications to all connected clients every 10 minutes
-	t.keepAlive = hap.NewKeepAlive(10*time.Minute, t.context)
-	go t.keepAlive.Start()
+	serverCtx, serverCancel := context.WithCancel(t.ctx)
+	defer serverCancel()
+	serverStop := make(chan struct{})
+	go func() {
+		s.ListenAndServe(serverCtx)
+		log.Debug.Println("server stopped")
+		serverStop <- struct{}{}
+	}()
 
-	// Listen until server.Stop() is called
-	s.ListenAndServe()
+	// Wait until mdns responder and server stopped
+	<-mdnsStop
+	<-serverStop
+	t.stopped <- struct{}{}
 }
 
-// Stop stops the ip transport by unpublishing the mDNS service.
-func (t *ipTransport) Stop() {
+// Stop stops the ip transport by stopping the http server and unpublishing the mDNS service.
+func (t *ipTransport) Stop() <-chan struct{} {
+	t.cancel()
 
-	if t.keepAlive != nil {
-		t.keepAlive.Stop()
-	}
-
-	if t.mdns != nil {
-		t.mdns.Stop()
-	}
-
-	if t.server != nil {
-		t.server.Stop()
-	}
+	return t.stopped
 }
 
 // isPaired returns true when the transport is already paired
@@ -174,9 +213,9 @@ func (t *ipTransport) isPaired() bool {
 }
 
 func (t *ipTransport) updateMDNSReachability() {
-	if mdns := t.mdns; mdns != nil {
-		t.config.discoverable = t.isPaired() == false
-		mdns.Update()
+	t.config.discoverable = t.isPaired() == false
+	if t.handle != nil {
+		t.handle.UpdateText(t.config.txtRecords(), t.responder)
 	}
 }
 
@@ -202,15 +241,6 @@ func (t *ipTransport) addAccessory(a *accessory.Accessory) {
 			}
 			c.OnValueUpdate(onChange)
 		}
-	}
-
-}
-
-func (t *ipTransport) updateConfig() {
-	t.config.updateConfigHash(t.container.ContentHash())
-	t.config.save(t.storage)
-	if t.mdns != nil {
-		t.mdns.Update()
 	}
 }
 
@@ -247,5 +277,13 @@ func (t *ipTransport) Handle(ev interface{}) {
 		t.updateMDNSReachability()
 	default:
 		break
+	}
+}
+
+func (t *ipTransport) updateConfig() {
+	t.config.updateConfigHash(t.container.ContentHash())
+	t.config.save(t.storage)
+	if t.mdns != nil {
+		t.mdns.Update()
 	}
 }

--- a/homekit/bridge/mdns.go
+++ b/homekit/bridge/mdns.go
@@ -1,41 +1,52 @@
 package bridge
 
 import (
+	"context"
+	"github.com/brutella/dnssd"
 	"github.com/brutella/hc/log"
-	"github.com/grandcat/zeroconf"
-	"golang.org/x/net/idna"
-
-	"fmt"
 	"net"
-	"os"
 	"strings"
 )
 
 // MDNSService represents a mDNS service.
 type MDNSService struct {
-	config *Config
-	server *zeroconf.Server
+	config    *Config
+	responder dnssd.Responder
+	handle    dnssd.ServiceHandle
+}
+
+func newService(config *Config) dnssd.Service {
+	// 2016-03-14(brutella): Replace whitespaces (" ") from service name
+	// with underscores ("_")to fix invalid http host header field value
+	// produces by iOS.
+	//
+	// [Radar] http://openradar.appspot.com/radar?id=4931940373233664
+	stripped := strings.Replace(config.name, " ", "_", -1)
+
+	var ips []net.IP
+	if ip := net.ParseIP(config.IP); ip != nil {
+		ips = append(ips, ip)
+	}
+
+	service := dnssd.NewService(stripped, "_hap._tcp.", "local.", "", ips, config.servePort)
+	service.Text = config.txtRecords()
+
+	return service
 }
 
 // NewMDNSService returns a new service based for the bridge name, id and port.
 func NewMDNSService(config *Config) *MDNSService {
+	// TODO handle error
+	responder, _ := dnssd.NewResponder()
+
 	return &MDNSService{
-		config: config,
+		config:    config,
+		responder: responder,
 	}
 }
 
-// IsPublished returns true when the service is published.
-func (s *MDNSService) IsPublished() bool {
-	return s.server != nil
-}
-
 // Publish announces the service for the machine's ip address on a random port using mDNS.
-func (s *MDNSService) Publish() error {
-	// Host should end with '.'
-	hostname, _ := os.Hostname()
-	host := fmt.Sprintf("%s.", strings.Trim(hostname, "."))
-	text := s.config.txtRecords()
-
+func (s *MDNSService) Publish(ctx context.Context) error {
 	// 2016-03-14(brutella): Replace whitespaces (" ") from service name
 	// with underscores ("_")to fix invalid http host header field value
 	// produces by iOS.
@@ -43,30 +54,36 @@ func (s *MDNSService) Publish() error {
 	// [Radar] http://openradar.appspot.com/radar?id=4931940373233664
 	stripped := strings.Replace(s.config.name, " ", "_", -1)
 
-	if puny, err := idna.ToASCII(stripped); err == nil && puny != "" {
-		stripped = puny
+	var ips []net.IP
+	if ip := net.ParseIP(s.config.IP); ip != nil {
+		ips = append(ips, ip)
 	}
 
-	server, err := zeroconf.RegisterProxy(stripped, "_hap._tcp.", "local", s.config.servePort, host, []string{s.config.IP}, text, []net.Interface{})
+	service := dnssd.NewService(stripped, "_hap._tcp.", "local.", "", ips, s.config.servePort)
+	service.Text = s.config.txtRecords()
+	handle, err := s.responder.Add(service)
 	if err != nil {
 		log.Info.Panic(err)
 	}
 
-	s.server = server
-	return err
+	s.handle = handle
+
+	return s.responder.Respond(ctx)
 }
 
 // Update updates the mDNS txt records.
 func (s *MDNSService) Update() {
-	if s.server != nil {
+	if s.handle != nil {
 		txt := s.config.txtRecords()
-		s.server.SetText(txt)
+		s.handle.UpdateText(txt, s.responder)
 		log.Debug.Println(txt)
 	}
 }
 
 // Stop stops the running mDNS service.
 func (s *MDNSService) Stop() {
-	s.server.Shutdown()
-	s.server = nil
+	if s.handle != nil {
+		s.responder.Remove(s.handle)
+		s.handle = nil
+	}
 }

--- a/homekit/bridge/transport.go
+++ b/homekit/bridge/transport.go
@@ -1,0 +1,11 @@
+package bridge
+
+// Transport provides accessories over a network.
+type Transport interface {
+	// Start starts the transport
+	Start()
+
+	// Stop stops the transport
+	// Use the returned channel to wait until the transport is fully stopped.
+	Stop() <-chan struct{}
+}

--- a/messaging/flagmqtt/setup.go
+++ b/messaging/flagmqtt/setup.go
@@ -49,16 +49,14 @@ func NewPersistentMqtt(config ClientConfig) (mqttClient mq.Client, err error) {
 	if useTls {
 		tlsCfg, err = setupTLS(caPath, certPath, keyPath)
 		if err != nil {
-			return
+			return nil, err
 		}
 	}
 
 	clientId := config.ClientID
 
 	if clientId == "" {
-		var rndUuid uuid.UUID
-		rndUuid = uuid.NewV4()
-		clientId = rndUuid.String()
+		clientId = NewUniqueIdentifier()
 	}
 
 	opts := mq.NewClientOptions().


### PR DESCRIPTION
* brutella/hc
* eclipse/paho
* satori/go.uuid

Some dependencies have remained around in `Gopkg.toml` even though we no longer (directly) depend on them, so these got removed:
* golang.org/x/net
* spf13/pflag
* oleksandr/bonjour
* miekg/dns

Note: though brutella/dnssd is directly imported in `homekit/bridge/mdns.go` it's not declared as a dependency in `Gopkg.toml` b/c it's vendored by brutella/hc. This ensures the vendored version is picked up on by the go toolchain during builds.