### PR TITLE
mdns updates

### DIFF
--- a/cmd/hemtjanst/main.go
+++ b/cmd/hemtjanst/main.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	name     = flag.String("name", "hemtjanst", "Name of bridge instance")
-	addr     = flag.String("address", "127.0.0.1", "IP or hostname for Hemtjänst to bind on")
+	addr     = flag.String("address", "", "IP or hostname for Hemtjänst to bind on")
 	port     = flag.String("port", "12345", "Port for Hemtjänst to bind on")
 	pin      = flag.String("pin", "01020304", "Pairing pin for the HomeKit bridge")
 	dbPath   = flag.String("db.path", "./db", "Path to store the database with HomeKit key pairs etc.")

--- a/homekit/bridge/config.go
+++ b/homekit/bridge/config.go
@@ -1,12 +1,9 @@
 package bridge
 
 import (
-	"errors"
 	"fmt"
-	"net"
 	"reflect"
 
-	"github.com/brutella/hc/log"
 	"github.com/brutella/hc/util"
 	"github.com/gosexy/to"
 )
@@ -41,16 +38,11 @@ type Config struct {
 }
 
 func defaultConfig(name string) *Config {
-	ip, err := getFirstLocalIPAddr()
-	if err != nil {
-		log.Info.Panic(err)
-	}
 
 	return &Config{
 		StoragePath:  name,
 		Pin:          "00102003", // default pin
 		Port:         "",         // empty string means that we get port from assigned by the system
-		IP:           ip.String(),
 		name:         name,
 		id:           util.MAC48Address(util.RandomHexString()),
 		version:      1,
@@ -124,33 +116,4 @@ func (cfg *Config) updateConfigHash(hash []byte) {
 	}
 
 	cfg.configHash = hash
-}
-
-// getFirstLocalIPAddr returns the first available IP address of the local machine
-// This is a fix for Beaglebone Black where net.LookupIP(hostname) return no IP address.
-func getFirstLocalIPAddr() (net.IP, error) {
-	addrs, err := net.InterfaceAddrs()
-	if err != nil {
-		return nil, err
-	}
-
-	for _, addr := range addrs {
-		var ip net.IP
-		switch v := addr.(type) {
-		case *net.IPNet:
-			ip = v.IP
-		case *net.IPAddr:
-			ip = v.IP
-		}
-		if ip == nil || ip.IsLoopback() || ip.IsUnspecified() {
-			continue
-		}
-		ip = ip.To4()
-		if ip == nil {
-			continue // not an ipv4 address
-		}
-		return ip, nil
-	}
-
-	return nil, errors.New("Could not determine ip address")
 }

--- a/homekit/bridge/mdns.go
+++ b/homekit/bridge/mdns.go
@@ -1,20 +1,13 @@
 package bridge
 
 import (
-	"context"
+	"fmt"
 	"net"
+	"os"
 	"strings"
 
 	"github.com/brutella/dnssd"
-	"github.com/brutella/hc/log"
 )
-
-// MDNSService represents a mDNS service.
-type MDNSService struct {
-	config    *Config
-	responder dnssd.Responder
-	handle    dnssd.ServiceHandle
-}
 
 func newService(config *Config) dnssd.Service {
 	// 2016-03-14(brutella): Replace whitespaces (" ") from service name
@@ -25,13 +18,21 @@ func newService(config *Config) dnssd.Service {
 	stripped := strings.Replace(config.name, " ", "_", -1)
 
 	var ips []net.IP
-	if ip := net.ParseIP(config.IP); ip != nil {
-		ips = append(ips, ip)
+	if config.IP != "" {
+		if ip := net.ParseIP(config.IP); ip != nil {
+			ips = append(ips, ip)
+		}
+	}
+
+	hostname, _ := os.Hostname()
+	if hostname == "" {
+		hostname = "hap"
 	}
 
 	sdConfig := dnssd.Config{
 		Name:   stripped,
 		Type:   "_hap._tcp",
+		Host:   fmt.Sprintf("%s-%s", hostname, stripped),
 		Domain: "local",
 		IPs:    ips,
 		Port:   config.servePort,
@@ -40,66 +41,4 @@ func newService(config *Config) dnssd.Service {
 	service.Text = config.txtRecords()
 
 	return service
-}
-
-// NewMDNSService returns a new service based for the bridge name, id and port.
-func NewMDNSService(config *Config) *MDNSService {
-	// TODO handle error
-	responder, _ := dnssd.NewResponder()
-
-	return &MDNSService{
-		config:    config,
-		responder: responder,
-	}
-}
-
-// Publish announces the service for the machine's ip address on a random port using mDNS.
-func (s *MDNSService) Publish(ctx context.Context) error {
-	// 2016-03-14(brutella): Replace whitespaces (" ") from service name
-	// with underscores ("_")to fix invalid http host header field value
-	// produces by iOS.
-	//
-	// [Radar] http://openradar.appspot.com/radar?id=4931940373233664
-	stripped := strings.Replace(s.config.name, " ", "_", -1)
-
-	var ips []net.IP
-	if ip := net.ParseIP(s.config.IP); ip != nil {
-		ips = append(ips, ip)
-	}
-
-	sdConfig := dnssd.Config{
-		Name:   stripped,
-		Type:   "_hap._tcp",
-		Domain: "local",
-		IPs:    ips,
-		Port:   s.config.servePort,
-	}
-
-	service, _ := dnssd.NewService(sdConfig)
-	service.Text = s.config.txtRecords()
-	handle, err := s.responder.Add(service)
-	if err != nil {
-		log.Info.Panic(err)
-	}
-
-	s.handle = handle
-
-	return s.responder.Respond(ctx)
-}
-
-// Update updates the mDNS txt records.
-func (s *MDNSService) Update() {
-	if s.handle != nil {
-		txt := s.config.txtRecords()
-		s.handle.UpdateText(txt, s.responder)
-		log.Debug.Println(txt)
-	}
-}
-
-// Stop stops the running mDNS service.
-func (s *MDNSService) Stop() {
-	if s.handle != nil {
-		s.responder.Remove(s.handle)
-		s.handle = nil
-	}
 }


### PR DESCRIPTION
* Default to listening on all interfaces instead of 127.0.0.1
* Remove auto-detection of IP address
* Remove old mdns code no longer in use
* Create mdns hostname from real hostname + service name