### PR TITLE
Fix using TLS for mqtt broker

### DIFF
--- a/messaging/flagmqtt/setup.go
+++ b/messaging/flagmqtt/setup.go
@@ -60,7 +60,6 @@ func NewPersistentMqtt(config ClientConfig) (mqttClient mq.Client, err error) {
 	}
 
 	opts := mq.NewClientOptions().
-		AddBroker(fmt.Sprintf("tcp://%s", address)).
 		SetClientID(clientId).
 		SetConnectTimeout(time.Duration(connectionTimeout) * time.Second).
 		SetKeepAlive(time.Duration(keepAlive) * time.Second).
@@ -96,6 +95,9 @@ func NewPersistentMqtt(config ClientConfig) (mqttClient mq.Client, err error) {
 	}
 	if useTls {
 		opts.SetTLSConfig(tlsCfg)
+		opts.AddBroker(fmt.Sprintf("ssl://%s", address))
+	} else {
+		opts.AddBroker(fmt.Sprintf("tcp://%s", address))
 	}
 
 	return mq.NewClient(opts), nil


### PR DESCRIPTION
Fix connecting to mqtt over TLS 

From paho mqtt documentation:
```
AddBroker adds a broker URI to the list of brokers to be used. The format should be scheme://host:port
Where "scheme" is one of "tcp", "ssl", or "ws", "host" is the ip-address (or hostname)
```